### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Description: Deterministic Pena-Yohai initial estimator for robust S estimators
 Imports:
     robustbase
 Suggests:
-    testthat
+    testthat,
+    digest
 License: GPL (>= 2)
 URL: https://github.com/dakep/pyinit
 BugReports: https://github.com/dakep/pyinit/issues


### PR DESCRIPTION
testthat no longer imports digest, so you need to suggest it.